### PR TITLE
Support for in2code/powermail V-12.0 (Early release)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,4 @@
+2023-10-18         [RELEASE] Release of powermailautocomplete 2.2.0 (Vladimir Falcon)
+2023-10-18 961e3df Simplify Form Text and Textarea ViewHelpers. (Vladimir Falcon)
+2023-10-18 32a72d3 Simplify class FormViewHelper to improve backward compatibility (Vladimir Falcon)
+2023-10-18 4d247a4 Update powermail requirement (Vladimir Falcon Piva)

--- a/Classes/ViewHelpers/Form/TextareaViewHelper.php
+++ b/Classes/ViewHelpers/Form/TextareaViewHelper.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /*
@@ -48,7 +47,7 @@ use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
  *
  *    <textarea name="myTextArea">This is shown inside the textarea</textarea>
  */
-class TextareaViewHelper extends AbstractFormFieldViewHelper
+final class TextareaViewHelper extends AbstractFormFieldViewHelper
 {
     /**
      * @var string
@@ -86,11 +85,6 @@ class TextareaViewHelper extends AbstractFormFieldViewHelper
         $this->addAdditionalIdentityPropertiesIfNeeded();
         $this->setErrorClassAttribute();
 
-
-        $autocomplete = $this->arguments['autocomplete'] ?? null;
-        if(!empty($autocomplete)) {
-            $this->tag->addAttribute('autocomplete', $autocomplete);
-        }
         return $this->tag->render();
     }
 }

--- a/Classes/ViewHelpers/Form/TextfieldViewHelper.php
+++ b/Classes/ViewHelpers/Form/TextfieldViewHelper.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 /*
@@ -46,7 +45,7 @@ use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
  *
  *    <input type="text" name="myTextBox" value="default value" />
  */
-class TextfieldViewHelper extends AbstractFormFieldViewHelper
+final class TextfieldViewHelper extends AbstractFormFieldViewHelper
 {
     /**
      * @var string
@@ -63,11 +62,11 @@ class TextfieldViewHelper extends AbstractFormFieldViewHelper
         $this->registerTagAttribute('size', 'int', 'The size of the input field');
         $this->registerTagAttribute('placeholder', 'string', 'The placeholder of the textfield');
         $this->registerTagAttribute('pattern', 'string', 'HTML5 validation pattern');
+        $this->registerTagAttribute('autocomplete', 'string', 'The autocomplete token',);
         $this->registerArgument('errorClass', 'string', 'CSS class to set if there are errors for this ViewHelper', false, 'f3-form-error');
         $this->registerUniversalTagAttributes();
         $this->registerArgument('required', 'bool', 'If the field is required or not', false, false);
         $this->registerArgument('type', 'string', 'The field type, e.g. "text", "email", "url" etc.', false, 'text');
-        $this->registerTagAttribute('autocomplete', 'string', 'The autocomplete token',);
     }
 
     public function render(): string
@@ -90,11 +89,6 @@ class TextfieldViewHelper extends AbstractFormFieldViewHelper
 
         if ($required !== false) {
             $this->tag->addAttribute('required', 'required');
-        }
-
-        $autocomplete = $this->arguments['autocomplete'] ?? null;
-        if (!empty($autocomplete)) {
-            $this->tag->addAttribute('autocomplete', $autocomplete);
         }
 
         $this->addAdditionalIdentityPropertiesIfNeeded();

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright notice
@@ -29,38 +30,12 @@
 namespace TRAW\Powermailautocomplete\ViewHelpers;
 
 /**
- * Form ViewHelper. Generates a :html:`<form>` Tag.
+ * Extends FormViewHelper class
  *
- * Basic usage
- * ===========
+ * Register attribute autocomplete for form tag
  *
- * Use :html:`<f:form>` to output an HTML :html:`<form>` tag which is targeted
- * at the specified action, in the current controller and package.
- * It will submit the form data via a POST request. If you want to change this,
- * use :html:`method="get"` as an argument.
- *
- * Examples
- * ========
- *
- * A complex form with a specified encoding type
- * ---------------------------------------------
- *
- * Form with enctype set::
- *
- *    <f:form action=".." controller="..." package="..." enctype="multipart/form-data">...</f:form>
- *
- * A Form which should render a domain object
- * ------------------------------------------
- *
- * Binding a domain object to a form::
- *
- *    <f:form action="..." name="customer" object="{customer}">
- *       <f:form.hidden property="id" />
- *       <f:form.textbox property="name" />
- *    </f:form>
- *
- * This automatically inserts the value of ``{customer.name}`` inside the
- * textbox and adjusts the name of the textbox accordingly.
+ * For more information:
+ * @see \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
  */
 class FormViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
 {
@@ -71,60 +46,7 @@ class FormViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
     public function initializeArguments(): void
     {
         parent::initializeArguments();
-        $this->registerTagAttribute('autocomplete', 'string', 'The autocomplete token',);
+        $this->registerTagAttribute('autocomplete', 'string', 'The autocomplete token', false);
     }
 
-    /**
-     * Render the form.
-     *
-     * @return string rendered form
-     */
-    public function render(): string
-    {
-        $this->setFormActionUri();
-        if (isset($this->arguments['method']) && strtolower($this->arguments['method']) === 'get') {
-            $this->tag->addAttribute('method', 'get');
-        } else {
-            $this->tag->addAttribute('method', 'post');
-        }
-
-        if (isset($this->arguments['novalidate']) && $this->arguments['novalidate'] === true) {
-            $this->tag->addAttribute('novalidate', 'novalidate');
-        }
-
-        $this->addFormObjectNameToViewHelperVariableContainer();
-        $this->addFormObjectToViewHelperVariableContainer();
-        $this->addFieldNamePrefixToViewHelperVariableContainer();
-        $this->addFormFieldNamesToViewHelperVariableContainer();
-        $formContent = $this->renderChildren();
-
-        if (isset($this->arguments['hiddenFieldClassName']) && $this->arguments['hiddenFieldClassName'] !== null) {
-            $content = LF . '<div class="' . htmlspecialchars($this->arguments['hiddenFieldClassName']) . '">';
-        } else {
-            $content = LF . '<div>';
-        }
-
-        $content .= $this->renderHiddenIdentityField($this->arguments['object'] ?? null, $this->getFormObjectName());
-        $content .= $this->renderAdditionalIdentityFields();
-        $content .= $this->renderHiddenReferrerFields();
-
-        // Render the trusted list of all properties after everything else has been rendered
-        $content .= $this->renderTrustedPropertiesField();
-
-        $content .= LF . '</div>' . LF;
-        $content .= $formContent;
-        $this->tag->setContent($content);
-        $this->removeFieldNamePrefixFromViewHelperVariableContainer();
-        $this->removeFormObjectFromViewHelperVariableContainer();
-        $this->removeFormObjectNameFromViewHelperVariableContainer();
-        $this->removeFormFieldNamesFromViewHelperVariableContainer();
-        $this->removeCheckboxFieldNamesFromViewHelperVariableContainer();
-
-        $autocomplete = $this->arguments['autocomplete'] ?? null;
-        if (!empty($autocomplete)) {
-            $this->tag->addAttribute('autocomplete', $autocomplete);
-        }
-
-        return $this->tag->render();
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "typo3/cms-core": "^11.5 || ^12.4",
     "php": "^7.4 || ^8.0",
-    "in2code/powermail": "^9.0 ||  ^10.5 || ^11.0",
+    "in2code/powermail": "^9.0 ||  ^10.5 || ^11.0 || ^12.0",
     "evoweb/extender": "^9.0"
   },
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Hi,

thanks for the extension. We are setting up a new TYPO3 system with the early release version from powermail V-12. 
To be able to use the extension  I had to update the requirements in the composer file. 

I also made some cosmetic changes to the Form, Textfield and Textarea viewhelpers.

Do not hesitate to write me if you have any question. 

Regards Vladi